### PR TITLE
Locating official WASI Builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WASI wheels
 
-This repository contains build files to produce WASI builds of a set of Python packages which do not have official WASI builds.
+This repository contains build files to produce WASI builds of a set of Python packages which do not have [official WASI builds](https://pypi.org/search/?c=Environment+%3A%3A+WebAssembly+%3A%3A+WASI).
 
 ## Building the Packages
 


### PR DESCRIPTION
- The README states "This repository contains build files to produce WASI builds of a set of Python packages which do not have official WASI builds"
- Is it right to assume that the way to find official wasi builds of packages is with the following pypi search filter? https://pypi.org/search/?c=Environment+%3A%3A+WebAssembly+%3A%3A+WASI
- If so this PR adds that link to the README. If not would be interested in alternative locations that could be mentioned.