### PR TITLE
Fix numpy build errors.

### DIFF
--- a/numpy/build.sh
+++ b/numpy/build.sh
@@ -26,7 +26,7 @@ export NPY_DISABLE_SVML=1
 export NPY_BLAS_ORDER=
 export NPY_LAPACK_ORDER=
 
-pip install cython setuptools
-(cd src && python3 setup.py build --disable-optimization -j 4)
+pip install cython setuptools==71.1.0
+( cd src && python3 setup.py build --disable-optimization -j 4 )
 
 cp -a src/build/lib.*/numpy build/


### PR DESCRIPTION
- Newer versions of distutils are incompatible in more than one way (e.g. missing distutils.msvccompiler on macos)
- Fixed syntax error for subshell invocation